### PR TITLE
Uninstaller Test-Path exception caught

### DIFF
--- a/FossaMail/tools/chocolateyUninstall.ps1
+++ b/FossaMail/tools/chocolateyUninstall.ps1
@@ -12,8 +12,9 @@ $unexe = Get-ItemProperty "$RegistryLocation\*" |
                      Where-Object { $_.displayname -match 'FossaMail'} |
                      Select-Object -ExpandProperty UninstallString
 
-
-if (Test-Path $unexe) {
+if ([string]::IsNullOrEmpty($unexe)) {
+	Throw "$packageName is not installed!"
+} elseif (Test-Path -Path $unexe) {
   $UninstallArgs = @{
      packageName = $packageName
      fileType = 'exe'
@@ -22,10 +23,6 @@ if (Test-Path $unexe) {
      validExitCodes = @(0)
   }
   Uninstall-ChocolateyPackage @UninstallArgs
-
 } else {
   Throw "$packageName uninstaller not found!"
 }
-
-
-


### PR DESCRIPTION
If Fossmail could not find the uninstaller in the registry then it failed with an uninfoirmative error message. A $null / empty uninstaller location passed to Test-Path would result in an exception. We now check this and show an informative message if the uninstall is not found.