### PR TITLE
✨ Adds mcr-r2015b package

### DIFF
--- a/manual/mcr-r2015b/LICENSE.txt
+++ b/manual/mcr-r2015b/LICENSE.txt
@@ -1,0 +1,97 @@
+The MathWorks, Inc.
+
+MATLAB COMPILER RUNTIME (MCR) LIBRARIES LICENSE
+
+1. LICENSE GRANT.   
+Subject to the restrictions below, The MathWorks, Inc. ("MathWorks") 
+hereby grants to you, whether you are an individual or an entity, a 
+license to install and use the MATLAB Compiler Runtime Libraries ("MCR"), 
+solely and expressly for the purpose of running software created with 
+the MATLAB Compiler (the "Application Software"), and for no other 
+purpose.  This license is personal, nonexclusive, and nontransferable. 
+
+2. LICENSE RESTRICTIONS.  
+You shall not modify or adapt the MCR for any reason.  You shall not 
+disassemble, decompile, or reverse engineer the MCR.  You shall not 
+alter or remove any proprietary or other legal notices on or in copies 
+of the MCR. Unless used to run Application Software, you shall not rent, 
+lease, or loan the MCR, time share the MCR, provide service bureau use, 
+or use the MCR for supporting any other party's use of the MCR. You 
+shall not sublicense, sell, or otherwise transfer the MCR to any third 
+party. You shall not republish any documentation which may be provided 
+in connection with the MCR.  All rights not granted, including without 
+limitation rights to reproduce, sublicense, rent, sell, distribute, 
+create derivative works, serve other software by means of, decompile, 
+reverse engineer, and disassemble the MCR, are expressly reserved by 
+MathWorks. 
+
+3. NO TECHNICAL SUPPORT.  
+Technical support is not provided by MathWorks for users of the MCR 
+under this license.  MathWorks may, at its sole discretion, offer bug 
+fixes or updates to the MCR.  
+
+4. TERM AND TERMINATION.  
+This license shall automatically terminate upon your failure to comply 
+with this license. 
+
+5. EXPORT CONTROL.  
+The MCR may be subject to U.S. and non-U.S. export control laws and 
+other applicable governmental export and import laws and regulations.  
+In exercising your rights under this license, you agree not to violate 
+any such laws and regulations.  You also represent and warrant that 
+  (i) you are not located in a country that is subject to a U.S. 
+  Government embargo, or that has been designated by the U.S. Government 
+  as a "terrorist supporting" country; and 
+  (ii) you are not listed on any U.S. Government list of prohibited or 
+  restricted parties. 
+
+6. U.S. GOVERNMENT LICENSEES:  
+You agree that the MCR qualifies as commercial computer software or 
+documentation as defined in the FAR and/or DFARS; that the terms and 
+conditions of this MATLAB COMPILER RUNTIME (MCR) LIBRARIES LICENSE shall 
+govern your use, reproduction, performance, display, and disclosure of 
+the MCR, superseding any inconsistent government provisions.  
+
+7. ASSIGNMENT.  
+You may not assign or otherwise transfer this license and its rights 
+and obligations hereunder, in whole or in part. 
+
+8. LIMITATION OF LIABILITY.  
+To the extent permitted by law, any liability of MathWorks (whether in 
+relation to breach of contract, negligence or otherwise) shall be 
+limited to ten dollars ($10.00 USD); and MathWorks shall have no 
+liability for any indirect or consequential loss (whether foreseeable 
+or otherwise and including loss of profits, loss of business, loss of 
+opportunity, and loss of use, or unauthorized use or access, of any 
+computer hardware or software).  Some states do not allow the exclusion 
+or limitation of incidental or consequential damages, so the above 
+exclusion or limitation may not apply to you. MathWorks' liability for 
+death or personal injury resulting from negligence or for any other 
+matter in relation to which liability by law cannot be excluded or 
+limited shall not be excluded or limited.  
+
+9. DISCLAIMER OF WARRANTIES.  
+The MCR is delivered "as is" and MathWorks makes and you receive no 
+additional express or implied warranties.  MathWorks hereby expressly 
+disclaims any and all other conditions, warranties, or other terms of 
+any kind or nature concerning the MCR (including, without limitation, 
+any with regard to noninfringement, merchantability, quality, accuracy, 
+or fitness for a particular purpose or for your purpose).  MathWorks 
+also expressly disclaims any warranties that may be implied from usage 
+of trade, course of dealing, or course of performance.  
+
+10. GOVERNING LAW; JURISDICTION.  
+This license shall be governed by the laws of the Commonwealth of 
+Massachusetts, United States of America, without regard to its conflicts 
+of law provisions. Neither the U.N. Convention on Contracts for the 
+International Sale of Goods nor the Uniform Computer Information 
+Transactions Act, or any version thereof ("UCITA"), shall apply to this 
+license. To the extent that UCITA is applicable, the parties agree to 
+opt out of the applicability of UCITA. 
+
+11. ENTIRE AGREEMENT.  
+This license contains the entire understanding of the parties with 
+respect to the MCR provided hereunder, and may not be modified or 
+amended except by written instrument, executed by MathWorks and you.  
+This license shall not supersede any product license you have with 
+MathWorks for the MATLAB Compiler. 

--- a/manual/mcr-r2015b/mcr-r2015b.nuspec
+++ b/manual/mcr-r2015b/mcr-r2015b.nuspec
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <!-- == PACKAGE SPECIFIC SECTION == -->
+    <id>mcr-r2015b</id>
+    <version>9.0</version>
+    <packageSourceUrl>https://github.com/teknowledgist/Chocolatey-packages/tree/master/manual/mcr-r2015b</packageSourceUrl>
+    <owners>teknowledgist</owners>
+    <!-- == SOFTWARE SPECIFIC SECTION == -->
+    <title>MATLAB Compiler Runtime R2015a</title>
+    <authors>The Mathworks, Inc.</authors>
+    <projectUrl>https://www.mathworks.com/products/compiler/matlab-runtime.html</projectUrl>
+    <iconUrl>https://cdn.rawgit.com/teknowledgist/Chocolatey-packages/master/Icons/matlab_icon.png</iconUrl>
+    <copyright>Copyright 2001-2014 The MathWorks, Inc.</copyright>
+    <licenseUrl>https://raw.githubusercontent.com/teknowledgist/Chocolatey-packages/master/manual/mcr-r2015b/LICENSE.txt</licenseUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <docsUrl>https://www.mathworks.com/help/compiler/deployment-process.html</docsUrl>
+    <bugTrackerUrl>https://www.mathworks.com/support/search_results.html?q=asset_type%3A%22Bug%2BReports%22+product%3A%22MATLAB+Compiler%22</bugTrackerUrl>
+    <tags>MATLAB compiler runtime math mathematics library</tags>
+    <summary>Run compiled MATLAB applications or components without installing MATLAB.</summary>
+    <description>MATLAB Runtime is a collection of shared libraries and code that enables the execution of compiled and packaged MATLAB applications on systems without an installed version of MATLAB.
+
+#### Notes
+* The version of the MATLAB Runtime necessary to run an application is tied to the version of MATLAB used to create the application.
+* Multiple versions of the MATLAB Runtime may simultaneously exist on a target machine. This allows applications compiled with different versions of the MATLAB Runtime to execute side by side on the same machine.
+* The MATLAB Runtime Compiler is large (700MB +).  It will take some time to download and install.
+    </description>
+    <dependencies>
+      <dependency id="vcredist2005" />
+      <dependency id="vcredist2008" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/manual/mcr-r2015b/tools/chocolateyinstall.ps1
+++ b/manual/mcr-r2015b/tools/chocolateyinstall.ps1
@@ -1,0 +1,39 @@
+﻿$ErrorActionPreference = 'Stop'
+
+$WorkSpace = Join-Path $env:TEMP "$env:ChocolateyPackageName.$env:ChocolateyPackageVersion"
+
+$WebFileArgs = @{
+   packageName  = $env:ChocolateyPackageName
+   FileFullPath = Join-Path $WorkSpace 'installer.exe'
+   Url          = 'https://ssd.mathworks.com/supportfiles/downloads/R2015b/deployment_files/R2015b/installers/win32/MCR_R2015b_win32_installer.exe'
+   Url64bit     = 'https://ssd.mathworks.com/supportfiles/downloads/R2015b/deployment_files/R2015b/installers/win64/MCR_R2015b_win64_installer.exe'
+   Checksum     = '74593c18b69c5abc0f72eb61ce28a85240fe567fd3b22e7bc4b7dda1251986e2'
+   Checksum64   = 'dd5eb527ed16cd029cc135ca6fffc80a40d7c402d01cec7deec88641f809d30b'
+   ChecksumType = 'sha256'
+   GetOriginalFileName = $true
+}
+
+$msgtext = 'MATLAB Runtime is large, so it may take awhile to download and install.  Please be patient.'
+Write-Host $msgtext -ForegroundColor Cyan
+
+$PackedInstaller = Get-ChocolateyWebFile @WebFileArgs
+
+$UnzipArgs = @{
+   PackageName = $env:ChocolateyPackageName
+   FileFullPath = $PackedInstaller
+   Destination  = $WorkSpace
+}
+
+Get-ChocolateyUnzip @UnzipArgs
+
+$Installer = (Get-ChildItem -Path "$WorkSpace\bin" -Include 'setup.exe' -Recurse).fullname
+
+$InstallArgs = @{
+   PackageName = $env:ChocolateyPackageName
+   File = $Installer
+   SilentArgs = '-mode silent -agreeToLicense yes'
+   UseOnlyPackageSilentArguments = $true
+}
+
+Install-ChocolateyInstallPackage @InstallArgs
+

--- a/manual/mcr-r2015b/tools/chocolateyuninstall.ps1
+++ b/manual/mcr-r2015b/tools/chocolateyuninstall.ps1
@@ -1,0 +1,28 @@
+﻿$ErrorActionPreference = 'Stop'
+
+$SoftwareName = "MATLAB Runtime $env:ChocolateyPackageVersion*"
+
+[array]$key = Get-UninstallRegistryKey -SoftwareName $SoftwareName
+
+if ($key.Count -eq 1) {
+   $UninstallArgs = @{
+      packageName    = $env:ChocolateyPackageName
+      softwareName   = $SoftwareName
+      fileType       = 'exe'
+      file           = $key[0].UninstallString -replace '(.*\.exe).*','$1'
+      silentArgs     = '"' + $key[0].InstallLocation + '" -mode silent'
+      validExitCodes = @(0)
+   }
+   Uninstall-ChocolateyPackage @UninstallArgs
+   if (Test-Path $key[0].InstallLocation) {
+      Remove-Item $key[0].InstallLocation -Recurse
+   }
+} elseif ($key.Count -eq 0) {
+   Write-Warning "$env:ChocolateyPackageName has already been uninstalled by other means."
+} elseif ($key.Count -gt 1) {
+   Write-Warning "$($key.Count) matches found!"
+   Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
+   Write-Warning "Please alert package maintainer the following keys were matched:"
+   $key | % {Write-Warning "- $($_.DisplayName)"}
+}
+


### PR DESCRIPTION
This PR should contain everything needed to support MATLAB Compiler Runtime R2015b 9.0.

Would you mind adding this version to the list of packages you maintain ?

