### PR TITLE
Better error handling to font helpers extension

### DIFF
--- a/extensions/chocolatey-font-helpers.extension/chocolatey-font-helpers.extension.nuspec
+++ b/extensions/chocolatey-font-helpers.extension/chocolatey-font-helpers.extension.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>chocolatey-font-helpers.extension</id>
-    <version>0.0.2</version>
+    <version>0.0.3</version>
     <packageSourceUrl>https://github.com/bcurran3/ChocolateyPackages/tree/master/chocolatey-font-helpers.extension</packageSourceUrl>
     <owners>bcurran3, Teknowledgist</owners>
     <!-- == SOFTWARE SPECIFIC SECTION == -->
@@ -44,6 +44,7 @@ Let the easy-peasy font packages flow!
     <releaseNotes>###CHANGE LOG:
 * 0.0.1 - initial release
 * 0.0.2 - Cleaned up and added multiple option
+* 0.0.3 - Better exception handling
     </releaseNotes>
     <bugTrackerUrl>https://github.com/bcurran3/ChocolateyPackages/issues</bugTrackerUrl>
   </metadata>

--- a/extensions/chocolatey-font-helpers.extension/extensions/Install-ChocolateyFont.ps1
+++ b/extensions/chocolatey-font-helpers.extension/extensions/Install-ChocolateyFont.ps1
@@ -99,8 +99,12 @@ function Install-ChocolateyFont {
          }
       } catch {
          Write-Warning "An error occured installing '$($File.FullName)'"
-         Write-Warning "$($error[0].ToString())"
-         $error.clear()
+         if ($null -ne $error -and $null -ne $error[0]) {
+            Write-Warning "$($error[0].ToString())"
+            $error.clear()
+         } else {
+            Write-Warning "$($_.ToString())"
+         }
       }
    }
    

--- a/extensions/chocolatey-font-helpers.extension/extensions/New-FontResourceType.ps1
+++ b/extensions/chocolatey-font-helpers.extension/extensions/New-FontResourceType.ps1
@@ -48,13 +48,13 @@ Function New-FontResourceType {
 
            public static int AddFont(string fontFilePath) {
                FileInfo fontFile = new FileInfo(fontFilePath);
-               if (!fontFile.Exists) { return 0; }
+               if (!fontFile.Exists) { throw new FileNotFoundException("Font file not found"); }
                try {
                    int retVal = AddFontResource(fontFilePath);
                    bool posted = PostMessage(HWND_BROADCAST, WM.FONTCHANGE, IntPtr.Zero, IntPtr.Zero);
                    return retVal;
                }
-               catch { return 0; }
+               catch { throw; }
            }
 
            public static int RemoveFont(string fontFileName) {
@@ -63,7 +63,7 @@ Function New-FontResourceType {
                    bool posted = PostMessage(HWND_BROADCAST, WM.FONTCHANGE, IntPtr.Zero, IntPtr.Zero);
                    return retVal;
                }
-               catch { return 0; }
+               catch { throw; }
            }
        }
    }

--- a/extensions/chocolatey-font-helpers.extension/extensions/Uninstall-ChocolateyFont.ps1
+++ b/extensions/chocolatey-font-helpers.extension/extensions/Uninstall-ChocolateyFont.ps1
@@ -88,8 +88,12 @@ function Uninstall-ChocolateyFont {
       catch
       {
          Write-Warning "An error occured removing '$Item'."
-         Write-Warning "$($error[0].ToString())"
-         $error.clear()
+         if ($null -ne $error -and $null -ne $error[0]) {
+            Write-Warning "$($error[0].ToString())"
+            $error.clear()
+         } else {
+            Write-Warning "$($_.ToString())"
+         }
       }
    }
    


### PR DESCRIPTION
Rethrow exceptions from the C# code and updated the PowerShell scripts to null check the $error variable first, or display the exception details otherwise.