### PR TITLE
Adjust case for remote-package-registry

### DIFF
--- a/automatic/miktex.install/tools/chocolateyinstall.ps1
+++ b/automatic/miktex.install/tools/chocolateyinstall.ps1
@@ -111,7 +111,7 @@ if ($key.Count -gt 1) {
          Throw 'Local Repository failure!'
       }
    } else {
-      $RepoSwitch = "--Remote-package-repository=`"$Repository`""
+      $RepoSwitch = "--remote-package-repository=`"$Repository`""
    }
 
    # Now, do the actual install from identified repository


### PR DESCRIPTION
The casing is wrong, the R shouldn't be in caps, should be `--remote-package-repository`

"miktexsetup.exe: --Remote-package-repository=https://ctan.math.illinois.... unknown option"