### PR TITLE
Fix Mixtex.install documentation for local repo path

### DIFF
--- a/automatic/miktex.install/miktex.install.nuspec
+++ b/automatic/miktex.install/miktex.install.nuspec
@@ -54,7 +54,7 @@ This package has only the MiKTeX setup utility embedded.  Any new install of MiK
 
 * On a workstation in the same network, you might use:
 
-`choco install miktex.install --params '"/RepoPath://localserver/MiKTeX-Repo"'`
+`choco install miktex.install --params '"/RepoPath:\\localserver\MiKTeX-Repo"'`
 ]]>
     </description>
     <releaseNotes>https://github.com/MiKTeX/miktex/releases/latest</releaseNotes>


### PR DESCRIPTION
Using slashes one would get this error message:
`ERROR: You cannot call a method on a null-valued expression.`

This is because in `tools/chocolateyinstall.ps1` line 41 there is bad
error checking.

Code example to reproduce:
```bash
PS C:\> (([uri]('//localserver/MiKTeX-Repo')).hostnametype.tostring())
You cannot call a method on a null-valued expression.
At line:1 char:1
+ (([uri]('//localserver/MiKTeX-Repo')).hostnametype.tostring())
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull
```

Using backslashes this line (and Chocolatey package install) works:
```bash
PS C:\> (([uri]('\\localserver\MiKTeX-Repo')).hostnametype.tostring())
Dns
```