### PR TITLE
allow for tools ending with `e`

### DIFF
--- a/automatic/lastools/tools/chocolateyInstall.ps1
+++ b/automatic/lastools/tools/chocolateyInstall.ps1
@@ -17,7 +17,7 @@ $exes = Get-ChildItem $ZipArgs.UnzipLocation -filter *.exe -Recurse |select -Exp
 $txts = Get-ChildItem $ZipArgs.UnzipLocation -filter *.txt -Recurse |select -ExpandProperty fullname
 
 foreach ($exe in $exes) {
-   if ($txts -notcontains ($exe.trim('.exe') + '_README.txt')) {
+   if ($txts -notcontains ($exe.replace('.exe', '') + '_README.txt')) {
       New-Item "$exe.ignore" -Type file -Force | Out-Null
    }
 }


### PR DESCRIPTION
before, this would ignore all tools ending with `e`, such as `lastile`