### PR TITLE
Push Nessus Agent Version

### DIFF
--- a/automatic/nessus-agent/tools/chocolateyinstall.ps1
+++ b/automatic/nessus-agent/tools/chocolateyinstall.ps1
@@ -3,11 +3,11 @@
 $packageArgs = @{
    packageName   = $env:ChocolateyPackageName
    fileType      = 'MSI'
-   url           = 'https://www.tenable.com/downloads/api/v1/public/pages/nessus-agents/downloads/15868/download?i_agree_to_tenable_license_agreement=true'
-   url64bit      = 'https://www.tenable.com/downloads/api/v1/public/pages/nessus-agents/downloads/15867/download?i_agree_to_tenable_license_agreement=true'
+   url           = 'https://www.tenable.com/downloads/api/v1/public/pages/nessus-agents/downloads/15974/download?i_agree_to_tenable_license_agreement=true'
+   url64bit      = 'https://www.tenable.com/downloads/api/v1/public/pages/nessus-agents/downloads/15973/download?i_agree_to_tenable_license_agreement=true'
    softwareName  = 'Nessus Agent*'
-   checksum      = '75141ded704b63fd42b4ebde45a1a3a29254e7e097aa511f5fd1369a6f94ee0e'
-   checksum64    = '792bf43ec5c777d97a520b66d60d4575deb53d03a9c8ab0214ca5d3ed9a3f694'
+   checksum      = '07a57ffa75ed3d96cf47f08a71f447b29611809fd0cfb83a5669ca346dd75151'
+   checksum64    = '415e32fe4bb18a52f864c2a0e19f03eab23ac63d77e9a7fc1cc6c5845446c681'
    checksumType  = 'sha256' 
    silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($Env:chocolateyPackageName).$($env:chocolateyPackageVersion).MsiInstall.log`" "
    validExitCodes= @(0, 3010, 1641)


### PR DESCRIPTION
The Download URL for Nessus Agent returns a 404 error.
I replaced the URL's and Checksums with the current version 10.1.2