### PR TITLE
Update VSTOR to 10.0.60910

### DIFF
--- a/manual/vstor2010/tools/chocolateyinstall.ps1
+++ b/manual/vstor2010/tools/chocolateyinstall.ps1
@@ -2,9 +2,9 @@
 
 $packageArgs = @{
    packageName  = $env:ChocolateyPackageName
-   url           = 'https://download.microsoft.com/download/C/A/8/CA86DFA0-81F3-4568-875A-7E7A598D4C1C/vstor_redist.exe'
+   url           = 'https://download.microsoft.com/download/8/6/4/8641e164-7796-4b34-81c7-30d24a5bd533/vstor_redist.exe'
    fileType      = 'EXE'
-   Checksum      = '2B656781C884647A5368DADB0A4D63488413EA59A86D73E1802308D526B2BF84'
+   Checksum      = '9511042EABB4123827D1799154B9B2754C8509CA742D4E1AEA919084563F0B1E'
    checksumType  = 'sha256'
    softwareName  = 'Microsoft Visual Studio 2010 Tools for Office Runtime*'
    silentArgs    = '/quiet /norestart'

--- a/manual/vstor2010/vstor2010.nuspec
+++ b/manual/vstor2010/vstor2010.nuspec
@@ -4,23 +4,23 @@
   <metadata>
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>vstor2010</id>
-    <version>10.0.60828</version>
+    <version>10.0.60910</version>
     <packageSourceUrl>https://github.com/teknowledgist/Chocolatey-packages/tree/master/manual/vstor2010</packageSourceUrl>
     <owners>aa.malta, Teknowledgist</owners>
     <!-- == SOFTWARE SPECIFIC SECTION == -->
     <title>Visual Studio 2010 Tools for Office Runtime </title>
     <authors>Microsoft</authors>
-    <projectUrl>https://www.microsoft.com/en-us/download/details.aspx?id=48217</projectUrl>
+    <projectUrl>https://www.microsoft.com/en-us/download/details.aspx?id=105522</projectUrl>
     <copyright>© Microsoft</copyright>
     <licenseUrl>https://github.com/teknowledgist/Chocolatey-packages/blob/master/manual/vstor2010/tools/LICENSE.md</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <tags>vstor2010 vstor VisualStudio Microsoft Office .NET dotnet runtime </tags>
     <summary>Interface MS Office and .NET</summary>
-    <description>Visual Studio 2010 Tools for Office Runtime is required to run Microsoft Office based solutions built using Microsoft Visual Studio 2010, 2012, 2013, 2015 and 2017.
+    <description>Visual Studio 2010 Tools for Office Runtime is required to run Microsoft Office based solutions built using Microsoft Visual Studio 2010 and later.
 
 ### Prerequisite Note
 
- Running Office customizations built for this version of Visual Studio Tools for Office requires at least one of the following versions of Microsoft Office: 2007, 2010, 2013, 2016.  However, this package does not have an Office install as a pre-requisite.  It will attempt to discover an Office install before it proceeds, but it will only provide a warning if one is not found.
+ Running Office customizations built for this version of Visual Studio Tools for Office requires Microsoft Office 2007 or later.  However, this package does not have an Office install as a pre-requisite.  It will attempt to discover an Office install before it proceeds, but it will only provide a warning if one is not found.
     </description>
     <dependencies>
       <dependency id="dotnet4.5" version="4.5" />


### PR DESCRIPTION
This updates the vstor2010 package to use [VSTOR 10.0.60910](https://www.microsoft.com/en-us/download/details.aspx?id=105522), released 8/4/2023.