### PR TITLE
fix: retrieve all PDF24 Creator values for current version

### DIFF
--- a/automatic/pdf24/update.ps1
+++ b/automatic/pdf24/update.ps1
@@ -5,7 +5,7 @@ $AllVersions = 'https://creator.pdf24.org/listVersions.php'
 function global:au_GetLatest {
    $PageData = Invoke-WebRequest -Uri "$AllVersions" -UseBasicParsing
 
-   $latest = $PageData.RawContent -split '<tr>' | ? {$_ -match '<td>'} | select -first 4
+   $latest = $PageData.RawContent -split '<tr>' | ? {$_ -match '<td>'} | select -first 6
 
    $version = $latest -split '</?td>' | ? {$_ -match '^[0-9.]+'} | select -first 1
 


### PR DESCRIPTION
PDF24 Creator is available in ARM64, x64 and x86. For each platform an EXE and an MSI variant is provided. Thus there are 6 rows which must be examined to get the current version.