### PR TITLE
(soundswitch) Remove unnecessary dependency

### DIFF
--- a/automatic/soundswitch/soundswitch.nuspec
+++ b/automatic/soundswitch/soundswitch.nuspec
@@ -48,10 +48,7 @@ Comes in English, French, German, Korean, Norwegian Bokmål, Polish and Russian.
     If you want to return to a silent Toast Notification, open the file selector, and just do Cancel. Doing that will remove the set sound.
     </description>
     <releaseNotes>https://github.com/Belphemur/SoundSwitch/releases/latest</releaseNotes>
-    <!-- =============================== -->      
-    <dependencies>
-      <dependency id="dotnet5-desktop-runtime" version="5.0" />
-    </dependencies>
+    <!-- =============================== -->
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
This changeset removes `soundswitch`'s current dependency on `dotnet5-desktop-runtime`, for three reasons:

- `dotnet5-desktop-runtime` has long since been deprecated in favor of [`dotnet-5.0-desktopruntime`](https://community.chocolatey.org/packages/dotnet-5.0-desktopruntime), but was only just recently unlisted from the Community Repository. Use of deprecated packages should be avoided where practical.
- As of [SoundSwitch v5.8.0](https://github.com/Belphemur/SoundSwitch/releases/tag/v5.8.0), the .NET runtime binaries are packaged with the application. Therefore, a package dependency to decouple the software installation from its runtime dependency is now unnecessary.
- As of [SoundSwitch v6.1.1](https://github.com/Belphemur/SoundSwitch/releases/tag/v6.1.1), the application depends on a newer version of .NET, so a package dependency on 5.0 is no longer accurate.

Package installation was tested successfully against the latest version of the Chocolatey Test Environment, and the application itself runs fine as far as I can tell.